### PR TITLE
coredump bugfix for invalid directory input

### DIFF
--- a/src/pfind.c
+++ b/src/pfind.c
@@ -229,7 +229,7 @@ pfind_find_results_t * pfind_find(pfind_options_t * lopt){
       fprintf (stderr, "Pfind: cannot open directory '%s': %s\n", start_dir, strerror (errno));
       free(work);
       free(res);
-      return NULL;
+      pfind_abort("");
   }
   start_dir_length = strlen(start_dir);
 


### PR DESCRIPTION
root@localhost:~/io500/io500-main/build/pfind# ./pfind -v TEST2 -newer TEST2/a_1_01 -size 7651c -name *01* -C -q 10000
Pfind: cannot open directory '/root/io500/io500-main/build/pfind/-v': No such file or directory
Segmentation fault (core dumped)

#0  memcpy (__len=112, __src=0x0, __dest=0x1cd15c0) at /usr/include/x86_64-linux-gnu/bits/string3.h:51
51        return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
(gdb) where
#0  memcpy (__len=112, __src=0x0, __dest=0x1cd15c0) at /usr/include/x86_64-linux-gnu/bits/string3.h:51
#1  pfind_aggregrate_results (local=local@entry=0x0) at src/pfind.c:472
#2  0x000000000040170c in main (argc=12, argv=0x7fff54edb6c8) at src/pfind-main.c:56